### PR TITLE
Added dependency on project11_transforms.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,7 @@ find_package(catkin REQUIRED COMPONENTS
         actionlib
         dubins_curves
         dynamic_reconfigure
+        project11_transformations
         )
 
 find_package(GDAL REQUIRED)

--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,7 @@
   <depend>actionlib_msgs</depend>
   <depend>dubins_curves</depend>
   <depend>dynamic_reconfigure</depend>
+  <depend>project11_transformations</depend>
   <export>
   </export>
 </package>


### PR DESCRIPTION
When trying to build project11 without multiple process, using -j1, an error would occur where a header file from project11_transformations was not found. By building with multiple jobs, this error would sometimes go away if project11_transformations got built by time path_planner needed the header. A similar error occurred with dependencies between path_planner and mpc, but adding a dependency created circular dependencies.